### PR TITLE
Custom CSS

### DIFF
--- a/R/html_tufte_handout.R
+++ b/R/html_tufte_handout.R
@@ -16,6 +16,7 @@ NULL
 #' @param lib_dir Local directory to copy assets
 #' @param keep_md Keep knitr-generated markdown
 #' @param mathjax Include mathjax, "local" or "default"
+#' @param css Custom css. If not defined, tufterhandout.css is used
 #' @param pandoc_args Other arguments to pass to pandoc
 #' @param ... Additional function arguments to pass to the base R Markdown HTML
 #'   output formatter
@@ -27,10 +28,16 @@ html_tufte_handout <- function(self_contained = TRUE,
                                lib_dir = NULL,
                                keep_md = FALSE,
                                mathjax = "default",
-                               pandoc_args = NULL, ...) {
+                               pandoc_args = NULL,
+                               css = NULL, ...) {
 
-
- tufte_css <- system.file("tufterhandout.css", package = "tufterhandout")
+ # if custom css file is provided
+ if(!is.null(css) && css != "") {
+   tufte_css <- css
+ } else
+ {
+   tufte_css <- system.file("tufterhandout.css", package = "tufterhandout")
+ }
 
  if(identical(.Platform$OS.type, "windows")){
 

--- a/man/html_tufte_handout.Rd
+++ b/man/html_tufte_handout.Rd
@@ -6,7 +6,7 @@
 \usage{
 html_tufte_handout(self_contained = TRUE, theme = "default",
   lib_dir = NULL, keep_md = FALSE, mathjax = "default",
-  pandoc_args = NULL, ...)
+  pandoc_args = NULL, css = NULL, ...)
 }
 \arguments{
 \item{self_contained}{Include all dependencies}
@@ -20,6 +20,8 @@ html_tufte_handout(self_contained = TRUE, theme = "default",
 \item{mathjax}{Include mathjax, "local" or "default"}
 
 \item{pandoc_args}{Other arguments to pass to pandoc}
+
+\item{css}{Custom css. If not defined, tufterhandout.css is used}
 
 \item{...}{Additional function arguments to pass to the base R Markdown HTML
 output formatter}


### PR DESCRIPTION
The pull request includes only small change in `html_tufte_handout` function. 
It enables custom CSS if `css` argument is provided in the front-matter. If there is no `css` argument it behaves as before (uses CSS from the **tufterhandout** package).

**New functionality**
User can now define a custom CSS in front-matter. For example:

```
output: 
    tufterhandout::html_tufte_handout:
      css: tufterhandout_my_version.css
```

**Rationale:**
I have a case where only minor changes to format are needed.
and I think it is easier to change the .rmd front-matter than changing R function.
